### PR TITLE
Add preview tag

### DIFF
--- a/scripts/tags/preview.js
+++ b/scripts/tags/preview.js
@@ -30,7 +30,7 @@ function preview(args, content) {
   if (css) {
     out += '<header style="margin-bottom: -20px">css</header>' + hexo.render.renderSync({text: `\`\`\`js${css}\`\`\``, engine: 'markdown'});
   }
-  return `${out}<style>${css}</style><header style="margin-bottom: -20px">result</header>${html}<script>${js}</script>`;
+  return `${out}<style>${css}</style><header style="margin-bottom: -20px">result</header><div class="template">${html}</div><script>${js}</script>`;
 }
 
 hexo.extend.tag.register('preview', preview, {ends: true});

--- a/scripts/tags/preview.js
+++ b/scripts/tags/preview.js
@@ -1,8 +1,18 @@
-/**
- * center-quote.js | https://theme-next.org/docs/tag-plugins/
- */
-
 /* global hexo */
+
+/**
+ * {% preview %}
+ * <template>
+ *   html code
+ * </template>
+ * <style>
+ *   css code
+ * </style>
+ * <script>
+ *   js code
+ * </script>
+ * {% endpreview %}
+ */
 
 'use strict';
 

--- a/scripts/tags/preview.js
+++ b/scripts/tags/preview.js
@@ -1,0 +1,36 @@
+/**
+ * center-quote.js | https://theme-next.org/docs/tag-plugins/
+ */
+
+/* global hexo */
+
+'use strict';
+
+function getContent(content, tag) {
+  let index = content.indexOf(`<${tag}>`);
+  if (index === -1) {
+    return '';
+  }
+  let endIndex = content.indexOf(`</${tag}>`);
+  return content.substring(index + tag.length + 2, endIndex);
+}
+
+function preview(args, content) {
+  let js = getContent(content, 'script');
+  let css = getContent(content, 'style');
+  let html = getContent(content, 'template');
+
+  let out = '';
+  if (html) {
+    out += '<header style="margin-bottom: -20px">html</header>' + hexo.render.renderSync({text: `\`\`\`html${html}\`\`\``, engine: 'markdown'});
+  }
+  if (js) {
+    out += '<header style="margin-bottom: -20px">js</header>' + hexo.render.renderSync({text: `\`\`\`js${js}\`\`\``, engine: 'markdown'});
+  }
+  if (css) {
+    out += '<header style="margin-bottom: -20px">css</header>' + hexo.render.renderSync({text: `\`\`\`js${css}\`\`\``, engine: 'markdown'});
+  }
+  return `${out}<style>${css}</style><header style="margin-bottom: -20px">result</header>${html}<script>${js}</script>`;
+}
+
+hexo.extend.tag.register('preview', preview, {ends: true});


### PR DESCRIPTION
用于显示代码，同时预览，类似于codepan、jsxxxx什么的那些，便于直接写，且之前看到主题中的效果

Used to display code and preview at the same time, similar to those of codepan, jsxxxx, etc., easy to write directly, and see the effect in the theme before